### PR TITLE
Refactor: Implement server-side pagination for student views

### DIFF
--- a/app/composables/useFilteredStudents.ts
+++ b/app/composables/useFilteredStudents.ts
@@ -2,129 +2,46 @@
 import { useStudentTable } from '~/composables/useStudentTable'
 
 /**
- * Composable for filtering and paginating student data
+ * Composable for handling server-side paginated and filtered student data
  */
 export function useFilteredStudents(allStudents) {
-  const { search, sort, page, pageCount, groupFilter, programFilter } = useStudentTable()
+  // `allStudents` is now the direct response from the API, e.g.,
+  // { students: [...], totalItems: X, currentPage: Y, ... }
+
+  const { page, pageCount } = useStudentTable()
 
   const filteredStudents = computed(() => {
-    if (!allStudents.value?.students) {
-      return { students: [], total: 0 }
-    }
-
-    let result = [...allStudents.value.students]
-
-    // Apply search filter
-    if (search.value.trim()) {
-      const searchTerm = search.value.toLowerCase().trim()
-      result = result.filter((item) => {
-        const student = item.student
-        return (
-          (student.studentName || '').toLowerCase().includes(searchTerm)
-          || (student.studentLastname || '').toLowerCase().includes(searchTerm)
-          || (student.studentEmail || '').toLowerCase().includes(searchTerm)
-          || (student.studentNumber || '').toLowerCase().includes(searchTerm)
-          || (student.studentGroup || '').toLowerCase().includes(searchTerm)
-          || (student.studyProgram || '').toLowerCase().includes(searchTerm)
-          || (student.finalProjectTitle || '').toLowerCase().includes(searchTerm)
-          || (student.reviewerName || '').toLowerCase().includes(searchTerm)
-          || (student.supervisorEmail || '').toLowerCase().includes(searchTerm)
-        )
-      })
-    }
-
-    // Apply group filter
-    if (groupFilter.value) {
-      result = result.filter(item => item.student.studentGroup === groupFilter.value)
-    }
-
-    // Apply program filter
-    if (programFilter.value) {
-      result = result.filter(item => item.student.studyProgram === programFilter.value)
-    }
-
-    // Apply sorting
-    result.sort((a, b) => {
-      let valA, valB
-
-      if (sort.value.column === 'name') {
-        valA = `${a.student.studentName} ${a.student.studentLastname}`.toLowerCase()
-        valB = `${b.student.studentName} ${b.student.studentLastname}`.toLowerCase()
-      }
-      else if (sort.value.column === 'topic' || sort.value.column === 'actions') {
-        // Sort by topic status
-        const getTopicValue = (item) => {
-          if (!item.projectTopicRegistrations || item.projectTopicRegistrations.length === 0) {
-            return 0 // No topic
-          }
-          // Order: approved (3), submitted (2), needs_revision (1), head_approved (0)
-          const status = item.projectTopicRegistrations[0].status
-          switch (status) {
-            case 'approved': return 3
-            case 'submitted': return 2
-            case 'needs_revision': return 1
-            case 'head_approved': return 0
-            default: return -1
-          }
-        }
-
-        valA = getTopicValue(a)
-        valB = getTopicValue(b)
-      }
-      else if (sort.value.column === 'status') {
-        // Sort by report status
-        const getReportValue = (item) => {
-          // Has report and is signed (2), has report but unsigned (1), no report (0)
-          if (!item.supervisorReports || item.supervisorReports.length === 0) {
-            return 0
-          }
-          return item.supervisorReports[0].isSigned ? 2 : 1
-        }
-
-        valA = getReportValue(a)
-        valB = getReportValue(b)
-      }
-      else {
-        // Default sort by ID
-        valA = a.student.id
-        valB = b.student.id
-      }
-
-      // Apply sort direction
-      if (sort.value.direction === 'asc') {
-        return valA > valB ? 1 : -1
-      }
-      else {
-        return valA < valB ? 1 : -1
-      }
-    })
-
-    // Apply pagination
-    const totalCount = result.length
-    const startIndex = (page.value - 1) * pageCount.value
-    const paginatedResult = result.slice(startIndex, startIndex + pageCount.value)
-
+    // Client-side filtering, sorting, and pagination are removed.
+    // The data is already filtered, sorted, and paginated by the server.
     return {
-      students: paginatedResult,
-      total: totalCount
+      students: allStudents.value?.students || [], // Students for the current page from API
+      total: allStudents.value?.totalItems || 0 // Total items matching filters on server
     }
   })
 
-  // Get unique values for dropdowns
+  // Get unique values for dropdowns from the current page's data
   const uniqueGroups = computed(() => {
-    if (!allStudents.value?.students) return []
-    return [...new Set(allStudents.value.students.map(s => s.student.studentGroup))]
+    if (!allStudents.value?.students || allStudents.value.students.length === 0) return []
+    return [...new Set(allStudents.value.students.map(item => item.student.studentGroup))].filter(Boolean)
   })
 
   const uniquePrograms = computed(() => {
-    if (!allStudents.value?.students) return []
-    return [...new Set(allStudents.value.students.map(s => s.student.studyProgram))]
+    if (!allStudents.value?.students || allStudents.value.students.length === 0) return []
+    return [...new Set(allStudents.value.students.map(item => item.student.studyProgram))].filter(Boolean)
   })
 
-  // Pagination calculations
-  const pageTotal = computed(() => filteredStudents.value?.total || 0)
-  const pageFrom = computed(() => (page.value - 1) * Number(pageCount.value) + 1)
-  const pageTo = computed(() => Math.min(page.value * Number(pageCount.value), pageTotal.value))
+  // Pagination calculations based on server-provided total and current page settings
+  const pageTotal = computed(() => allStudents.value?.totalItems || 0)
+
+  const pageFrom = computed(() => {
+    if (!allStudents.value?.totalItems || allStudents.value.totalItems === 0) return 0
+    return (page.value - 1) * pageCount.value + 1
+  })
+
+  const pageTo = computed(() => {
+    if (!allStudents.value?.totalItems || allStudents.value.totalItems === 0) return 0
+    return Math.min(page.value * pageCount.value, allStudents.value.totalItems)
+  })
 
   return {
     filteredStudents,

--- a/app/composables/useStudentTable.ts
+++ b/app/composables/useStudentTable.ts
@@ -5,7 +5,7 @@
 export function useStudentTable() {
   const search = ref('')
   const selectedStatus = ref([])
-  const sort = ref({ column: 'id', direction: 'asc' as const })
+  const sort = ref({ column: 'studentLastname', direction: 'asc' as const })
   const page = ref(1)
   const pageCount = ref(10)
   const groupFilter = ref('')
@@ -26,10 +26,19 @@ export function useStudentTable() {
   // Dynamic years from API
   const { years: availableYears, isLoading: yearsLoading, error: yearsError } = useAcademicYears()
 
-  // Watch for filter changes to reset pagination
-  watch([search, groupFilter, programFilter, pageCount], () => {
+  // Watch for filter changes (excluding sort) to reset pagination
+  watch([search, groupFilter, programFilter, yearFilter, pageCount], () => {
     page.value = 1
   })
+
+  // Watch for sort changes to reset pagination
+  watch(
+    () => sort.value,
+    () => {
+      page.value = 1
+    },
+    { deep: true }
+  )
 
   // Make sure pageCount is always a number
   watch(pageCount, (newValue) => {

--- a/server/api/students/department.get.ts
+++ b/server/api/students/department.get.ts
@@ -1,4 +1,4 @@
-import { eq, and, inArray, desc } from 'drizzle-orm'
+import { eq, and, or, ilike, inArray, desc, asc, sql } from 'drizzle-orm'
 import { studentRecords, documents, videos, reviewerReports, supervisorReports, departmentHeads, projectTopicRegistrations, topicRegistrationComments } from '~~/server/database/schema'
 
 export default defineEventHandler(async (event) => {
@@ -23,11 +23,25 @@ export default defineEventHandler(async (event) => {
 
     const query = getQuery(event)
     const requestedYear = parseInt(query.year as string) || null
-    const departmentFilter = query.department as string || null
+    const departmentFilter = query.department as string || null // Existing filter
+    const page = parseInt(query.page as string) || 1
+    const limit = parseInt(query.limit as string) || 10
+    const sortBy = query.sortBy as string || 'studentLastname' // Default sort
+    const sortOrder = query.sortOrder as string === 'desc' ? 'desc' : 'asc'
+    const search = query.search as string || ''
+    const group = query.group as string || ''
+    const program = query.program as string || ''
 
     logger.debug('Request parameters', {
       requestedYear,
       departmentFilter,
+      page,
+      limit,
+      sortBy,
+      sortOrder,
+      search,
+      group,
+      program,
       query
     })
 
@@ -77,57 +91,159 @@ export default defineEventHandler(async (event) => {
       conditions.push(eq(studentRecords.department, departmentFilter))
     }
 
-    // First, if no year is specified, determine the latest year from the database
+    // Year filter: Determine latest year if not specified
     let latestYear = requestedYear
     if (!latestYear) {
-      logger.debug('No year specified, finding latest year')
+      logger.debug('No year specified, finding latest year based on initial conditions')
+      // Temporarily create base conditions for latest year query
+      const baseConditionsForYear = []
+      if (isDepartmentHead) {
+        baseConditionsForYear.push(eq(studentRecords.department, deptHeadResult[0].department))
+      }
+      else {
+        baseConditionsForYear.push(eq(studentRecords.supervisorEmail, userEmail))
+      }
+      if (departmentFilter) { // Also consider department filter if present
+        baseConditionsForYear.push(eq(studentRecords.department, departmentFilter))
+      }
 
       const latestYearResult = await db
         .select({ maxYear: studentRecords.currentYear })
         .from(studentRecords)
-        .where(conditions.length === 1 ? conditions[0] : and(...conditions))
+        .where(baseConditionsForYear.length > 0 ? and(...baseConditionsForYear) : undefined)
         .orderBy(desc(studentRecords.currentYear))
         .limit(1)
         .execute()
-
       latestYear = latestYearResult.length > 0 ? latestYearResult[0].maxYear : null
-
-      logger.info('Latest year determined', {
-        latestYear
-      })
+      logger.info('Latest year determined', { latestYear })
     }
 
-    // Add year filter
     if (latestYear) {
-      logger.debug('Applying year filter', { year: latestYear })
       conditions.push(eq(studentRecords.currentYear, latestYear))
+      logger.debug('Applied year filter', { year: latestYear })
     }
 
-    // Apply all conditions at once
-    logger.debug('Fetching student records with filters')
-    const studentRecordsResult = await db.select()
+    // Search filter
+    if (search) {
+      const searchLower = `%${search.toLowerCase()}%`
+      conditions.push(
+        or(
+          ilike(studentRecords.studentName, searchLower),
+          ilike(studentRecords.studentLastname, searchLower),
+          ilike(studentRecords.studentEmail, searchLower),
+          ilike(studentRecords.finalProjectTitle, searchLower),
+          ilike(studentRecords.studentGroup, searchLower),
+          ilike(studentRecords.studyProgram, searchLower)
+        )
+      )
+      logger.debug('Applied search filter', { search })
+    }
+
+    // Group filter
+    if (group) {
+      conditions.push(eq(studentRecords.studentGroup, group))
+      logger.debug('Applied group filter', { group })
+    }
+
+    // Program filter
+    if (program) {
+      conditions.push(eq(studentRecords.studyProgram, program))
+      logger.debug('Applied program filter', { program })
+    }
+
+    const combinedConditions = conditions.length > 0 ? and(...conditions) : undefined
+
+    // Count total items
+    logger.debug('Fetching total student count with all filters')
+    const totalItemsResult = await db
+      .select({ count: sql<number>`count(*)` })
       .from(studentRecords)
-      .where(conditions.length === 1 ? conditions[0] : and(...conditions))
+      .where(combinedConditions)
       .execute()
 
-    if (!studentRecordsResult?.length) {
-      logger.info('No students found matching criteria', {
+    const totalItems = totalItemsResult[0]?.count || 0
+    logger.info('Total items count determined', { totalItems, year: latestYear, isDepartmentHead })
+
+    if (totalItems === 0) {
+      logger.info('No students found matching all criteria', {
         year: latestYear,
         isDepartmentHead,
         department: isDepartmentHead ? deptHeadResult[0].department : null,
-        departmentFilter
+        departmentFilter,
+        search,
+        group,
+        program
       })
-
       return {
         students: [],
-        total: 0,
+        totalItems: 0,
+        currentPage: page,
+        totalPages: 0,
+        itemsPerPage: limit,
         year: latestYear,
         isDepartmentHead
       }
     }
 
-    logger.info('Student records found', {
+    // Sorting
+    let sortColumn
+    switch (sortBy) {
+      case 'name': // Assuming name refers to lastname
+        sortColumn = studentRecords.studentLastname
+        break
+      case 'finalProjectTitle':
+        sortColumn = studentRecords.finalProjectTitle
+        break
+      case 'studentGroup':
+        sortColumn = studentRecords.studentGroup
+        break
+      case 'studentEmail':
+        sortColumn = studentRecords.studentEmail
+        break
+      case 'studyProgram':
+        sortColumn = studentRecords.studyProgram
+        break
+      case 'supervisorName': // Assuming supervisor name is available or needs joining
+        sortColumn = studentRecords.supervisorName // Adjust if actual column name is different
+        break
+      default:
+        sortColumn = studentRecords.studentLastname
+    }
+    const orderedColumn = sortOrder === 'asc' ? asc(sortColumn) : desc(sortColumn)
+    logger.debug('Sorting parameters', { sortBy, sortOrder })
+
+    // Apply all conditions, sorting, and pagination for student records
+    logger.debug('Fetching paginated student records')
+    const studentRecordsResult = await db.select()
+      .from(studentRecords)
+      .where(combinedConditions)
+      .orderBy(orderedColumn)
+      .offset((page - 1) * limit)
+      .limit(limit)
+      .execute()
+
+    if (!studentRecordsResult?.length) {
+      logger.info('No students found for the current page', {
+        page,
+        limit,
+        year: latestYear,
+        isDepartmentHead
+      })
+      return {
+        students: [],
+        totalItems, // Still return totalItems
+        currentPage: page,
+        totalPages: Math.ceil(totalItems / limit),
+        itemsPerPage: limit,
+        year: latestYear,
+        isDepartmentHead
+      }
+    }
+
+    logger.info('Student records found for page', {
       count: studentRecordsResult.length,
+      page,
+      limit,
       year: latestYear,
       isDepartmentHead
     })
@@ -342,11 +458,27 @@ export default defineEventHandler(async (event) => {
         department: isDepartmentHead ? deptHeadResult[0].department : null
       })
 
+      const totalPages = Math.ceil(totalItems / limit)
+
+      logger.info('Response prepared successfully', {
+        studentCount: studentsData.length,
+        totalItems,
+        currentPage: page,
+        totalPages,
+        itemsPerPage: limit,
+        year: latestYear,
+        isDepartmentHead,
+        department: isDepartmentHead ? deptHeadResult[0].department : null
+      })
+
       return {
         students: studentsData,
-        total: studentRecordsResult.length,
+        totalItems,
+        currentPage: page,
+        totalPages,
+        itemsPerPage: limit,
         year: latestYear,
-        isDepartmentHead // Include this information so the UI can show appropriate options
+        isDepartmentHead
       }
     }
     catch (fetchError) {


### PR DESCRIPTION
This commit introduces server-side pagination, filtering, and sorting for the supervisor, department, and reviewer student tables.

Key changes include:

1.  **Backend API Modifications (`/api/students/*`):**
    *   Endpoints for supervisor, department, and reviewer data now accept pagination (`page`, `limit`), sorting (`sortBy`, `sortOrder`), and filtering (`search`, `year`, `group`, `program`) parameters.
    *   Database queries are updated to perform filtering, sorting, and pagination at the database level.
    *   API responses now include the current page's student data, total number of items matching all filters (`totalItems`), current page, total pages, and items per page.

2.  **Client-Side Data Handling Updates:**
    *   `useStudentTable.ts`: Default sort column changed to `studentLastname`. Watchers enhanced to reset the current page to 1 upon any change in filters, sorting, or items per page.
    *   `useStudentData.ts` (for supervisor & department): Refactored to pass all pagination/filter/sort parameters to the backend API. The `useLazyAsyncData` call now watches all relevant parameters to trigger data refetches. The `allStudents` ref now holds the full paginated response object from the API.
    *   `reviewer.vue`: Its custom data fetching logic (`useLazyAsyncData`) was similarly updated to interface with the modified reviewer API endpoint.
    *   `useFilteredStudents.ts`: All client-side filtering, sorting, and pagination logic has been removed. This composable now derives its data (`students` for the current page, `pageTotal`, `pageFrom`, `pageTo`) directly from the server's response data held in `allStudents`. Unique group/program lists for filters are now generated from the current page's data.

These changes aim to improve performance for large datasets and provide a more accurate and robust pagination experience across the application.